### PR TITLE
Use correct enum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+@ -0,0 +1,36 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+node_modules
+.pnp
+.pnp.js
+
+# testing
+coverage
+
+# next.js
+.next/
+out/
+build
+.swc/
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# turbo
+.turbo
+
+# ui
+dist/

--- a/README.md
+++ b/README.md
@@ -1614,7 +1614,7 @@ hello-world
       const {
          Stage,
          StageEvents,
-         ConnectionState,
+         StageConnectionState,
        } = IVSBroadcastClient;
      }
 ```
@@ -1694,7 +1694,7 @@ hello-world
     const {
       Stage, // Reference to the Stage class
       StageEvents, // Reference to the StageEvents object
-      ConnectionState, // Reference to the ConnectionState object
+      StageConnectionState, // Reference to the StageConnectionState object
     } = IVSBroadcastClient; // IVS Broadcast Client object
 
     if (!isInitializeComplete) return; // If the initialization is not complete, stop execution and return
@@ -1792,7 +1792,7 @@ hello-world
       ...
 
       stage.on(StageEvents.STAGE_CONNECTION_STATE_CHANGED, (state) => {
-        setIsConnected(state === ConnectionState.CONNECTED);
+        setIsConnected(state === StageConnectionState.CONNECTED);
 
         // Mutes the microphone stage stream and updates the inner text of the mic button to "Unmute Mic"
         micStageStream.setMuted(true);
@@ -1896,7 +1896,7 @@ hello-world
       const {
         Stage, // Reference to the Stage class
         StageEvents, // Reference to the StageEvents object
-        ConnectionState, // Reference to the ConnectionState object
+        StageConnectionState, // Reference to the StageConnectionState object
       } = IVSBroadcastClient; // IVS Broadcast Client object
 
       if (!isInitializeComplete) return; // If the initialization is not complete, stop execution and return
@@ -1920,7 +1920,7 @@ hello-world
       // Event listener for stage connection state changes
       stage.on(StageEvents.STAGE_CONNECTION_STATE_CHANGED, (state) => {
         // Update the connection status
-        setIsConnected(state === ConnectionState.CONNECTED);
+        setIsConnected(state === StageConnectionState.CONNECTED);
 
         // Mute the microphone stage stream and update the state for the mic button
         micStageStream.setMuted(true);

--- a/hello-world-with-grid-layout/client/src/app/utils/stageUtils.js
+++ b/hello-world-with-grid-layout/client/src/app/utils/stageUtils.js
@@ -88,7 +88,7 @@ export const joinStage = async (
   const {
     Stage, // Reference to the Stage class
     StageEvents, // Reference to the StageEvents object
-    ConnectionState, // Reference to the ConnectionState object
+    StageConnectionState, // Reference to the StageConnectionState object
   } = IVSBroadcastClient; // IVS Broadcast Client object
 
   if (!isInitializeComplete) return; // If the initialization is not complete, stop execution and return
@@ -114,7 +114,7 @@ export const joinStage = async (
   // Event listener for stage connection state changes
   stage.on(StageEvents.STAGE_CONNECTION_STATE_CHANGED, (state) => {
     // Update the connection status
-    setIsConnected(state === ConnectionState.CONNECTED);
+    setIsConnected(state === StageConnectionState.CONNECTED);
 
     // Mute the microphone stage stream and update the state for the mic button
     micStageStream.setMuted(true);

--- a/hello-world/client/src/app/utils/stageUtils.js
+++ b/hello-world/client/src/app/utils/stageUtils.js
@@ -82,7 +82,7 @@ export const joinStage = async (
   const {
     Stage, // Reference to the Stage class
     StageEvents, // Reference to the StageEvents object
-    ConnectionState, // Reference to the ConnectionState object
+    StageConnectionState, // Reference to the StageConnectionState object
   } = IVSBroadcastClient; // IVS Broadcast Client object
 
   if (!isInitializeComplete) return; // If the initialization is not complete, stop execution and return
@@ -106,7 +106,7 @@ export const joinStage = async (
   // Event listener for stage connection state changes
   stage.on(StageEvents.STAGE_CONNECTION_STATE_CHANGED, (state) => {
     // Update the connection status
-    setIsConnected(state === ConnectionState.CONNECTED);
+    setIsConnected(state === StageConnectionState.CONNECTED);
 
     // Mute the microphone stage stream and update the state for the mic button
     micStageStream.setMuted(true);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Add a `.gitignore` file
- Use the correct stage connection state enum, which is `StageConnectionState`, rather than `ConnectionState`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
